### PR TITLE
Updated senses & compatibility with 0.7.10. 

### DIFF
--- a/betternpcsheet.js
+++ b/betternpcsheet.js
@@ -1,13 +1,13 @@
 /**
- * @author Felix Müller aka syl3r86
+ * @author Felix Mï¿½ller aka syl3r86
  */
- 
+
 
 import ActorSheet5eNPC from "../../systems/dnd5e/module/actor/sheets/npc.js";
 
 //let Actor5eSheet = CONFIG.Actor.sheetClass;
 export class BetterNPCActor5eSheet extends ActorSheet5eNPC {
-								//  ActorSheet5eNPC
+    //  ActorSheet5eNPC
     get template() {
         // adding the #equals and #unequals handlebars helper
         Handlebars.registerHelper('equals', function (arg1, arg2, options) {
@@ -27,14 +27,14 @@ export class BetterNPCActor5eSheet extends ActorSheet5eNPC {
         const options = super.defaultOptions;
 
         mergeObject(options, {
-            classes: ["sheet","better-npc-sheet-container"],
+            classes: ["sheet", "better-npc-sheet-container"],
             width: 600,
             height: 300,
             blockFavTab: true
         });
         return options;
     }
-    
+
     getData() {
         const data = super.getData();
 
@@ -82,7 +82,7 @@ export class BetterNPCActor5eSheet extends ActorSheet5eNPC {
         html.find('.npc-item-name').click(event => {
             this._onItemSummary(event)
         });
-        
+
         // make categorys colapsable
         html.find('.body-tile-name').click(e => {
             let target = e.target.getAttribute('data-tile');
@@ -149,7 +149,7 @@ export class BetterNPCActor5eSheet extends ActorSheet5eNPC {
             this.saveState = true;
         } else {
             this._applySettingsMode(false, html);
-        }     
+        }
     }
 
     render(force = false, options = {}) {
@@ -173,10 +173,10 @@ export class BetterNPCActor5eSheet extends ActorSheet5eNPC {
             this.position.width = newWidth;
             this.position.height = newHeight;
         }
-        return super.render(force,options);
+        return super.render(force, options);
     }
 
-    async close() {        
+    async close() {
         if (this.isEditable) {
             this.object.update({ 'flags.betterNpcSheet.sheet.height': this.position.height, 'flags.betterNpcSheet.sheet.width': this.position.width });
         }
@@ -241,7 +241,7 @@ export class BetterNPCActor5eSheet extends ActorSheet5eNPC {
             }
         }
     }
-    
+
     /**
     * Organize and classify Items for NPC sheets
     * @private
@@ -301,7 +301,7 @@ export class BetterNPCActor5eSheet extends ActorSheet5eNPC {
                 }
                 let uses = {
                     value: 0,
-                    max:0
+                    max: 0
                 }
                 if (!isCantrip) {
                     uses.value = actorData.data.spells["spell" + lvl].value;
@@ -340,9 +340,9 @@ export class BetterNPCActor5eSheet extends ActorSheet5eNPC {
                             else if (i.type === "feat") features.push(i);
                             else if (i.type === "loot") loot.push(i);
                             else if (["equipment", "consumable", "tool", "backpack"].includes(i.type)) features.push(i);
-                            }
                         }
                     }
+                }
             }
         }
 
@@ -423,10 +423,10 @@ export class BetterNPCActor5eSheet extends ActorSheet5eNPC {
         if (data.actorId !== this.object.id || data.data === undefined) {
             return super._onDropItem(event, data);
         }
-        let typeFlag = data.data.flags ?.adnd5e ?.itemInfo ?.type;
+        let typeFlag = data.data.flags?.adnd5e?.itemInfo?.type;
         let targetTile = $(event.toElement).parents('.body-tile');
         let targetType = targetTile.length > 0 ? targetTile[0].dataset.tile : '';
-        
+
         if (targetType && targetType.indexOf('spell') === -1 && targetType !== typeFlag) {
             let item = this.actor.getOwnedItem(data.data._id);
             item.update({ 'flags.adnd5e.itemInfo.type': targetType });
@@ -471,7 +471,7 @@ export class BetterNPCActor5eSheet extends ActorSheet5eNPC {
         const dropTarget = event.target.closest(".item");
         const targetId = dropTarget ? dropTarget.dataset.itemId : null;
         const target = siblings.find(s => s.data._id === targetId);
-        
+
         // Perform the sort
         const sortUpdates = SortingHelpers.performIntegerSort(source, { target: target, siblings });
         const updateData = sortUpdates.map(u => {
@@ -534,16 +534,16 @@ Hooks.on('ready', () => {
     window.setTimeout(() => {
         if (window.BetterRolls) {
             console.log('BetterNPCSheet - Registering Better Rolls');
-            //window.BetterRolls.hooks.addActorSheet("BetterNPCActor5eSheet");
-            window.BetterRolls.hooks.registerActorSheet("BetterNPCActor5eSheet", ".item .npc-item-name", ".item-summary", {
-                itemButton: '.item .rollable',
-                abilityButton: ".ability h4.ability-name.rollable",
-                checkButton: ".ability div span.ability-mod",
-                saveButton: ".saves-div .save .rollable"
-            });
+            window.BetterRolls.hooks.addActorSheet("BetterNPCActor5eSheet");
+            // window.BetterRolls.hooks.registerActorSheet("BetterNPCActor5eSheet", ".item .npc-item-name", ".item-summary", {
+            //     itemButton: '.item .rollable',
+            //     abilityButton: ".ability h4.ability-name.rollable",
+            //     checkButton: ".ability div span.ability-mod",
+            //     saveButton: ".saves-div .save .rollable"
+            // });
         }
     }, 2000);
-    
+
 
     game.settings.register("betternpcsheet5e", "useIcons", {
         name: game.i18n.localize("BNPCSheet.useIcons"),

--- a/betternpcsheet5e/module.json
+++ b/betternpcsheet5e/module.json
@@ -9,6 +9,6 @@
 	"styles": ["/css/betternpcsheet.css", "css/rpg-awesome.css"],
 	"packs": [],
     "url": "https://github.com/Dinopaterno22/BetterNPCSheet5e",
-    "manifest": "https://github.com/Dinopaterno22/BetterNPCSheet5e/blob/master/module.json",
+    "manifest": "https://raw.githubusercontent.com/Dinopaterno22/BetterNPCSheet5e/master/betternpcsheet5e/module.json",
     "download": "https://github.com/Dinopaterno22/BetterNPCSheet5e/archive/master.zip"
 }

--- a/betternpcsheet5e/module.json
+++ b/betternpcsheet5e/module.json
@@ -2,13 +2,13 @@
 	"name": "betternpcsheet5e",
 	"title": "Better NPC Sheet 5e",
 	"description": "This module will replace the default 5e NPC sheet with an improved version. No change to the underlying data is made.",
-	"version": "0.4.8",
-	"author": "Felix aka syl3r86",
-	"systems": ["dnd5e", "dnd5eJP"],
-	"scripts": ["./betternpcsheet.js"],
+	"version": "0.9.2",
+	"author": "Felix#6196",
+	"systems": ["dnd5e"],
+	"esmodules": ["./betternpcsheet.js"],
 	"styles": ["/css/betternpcsheet.css", "css/rpg-awesome.css"],
 	"packs": [],
-    "url": "https://github.com/syl3r86/BetterNPCSheet5e",
-    "manifest": "https://raw.githubusercontent.com/syl3r86/BetterNPCSheet5e/master/module.json",
-    "download": "https://github.com/syl3r86/BetterNPCSheet5e/archive/master.zip"
+    "url": "https://github.com/Dinopaterno22/BetterNPCSheet5e",
+    "manifest": "https://github.com/Dinopaterno22/BetterNPCSheet5e/blob/master/module.json",
+    "download": "https://github.com/Dinopaterno22/BetterNPCSheet5e/archive/master.zip"
 }

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
     "name": "betternpcsheet5e",
     "title": "Better NPC Sheet 5e",
     "description": "This module will replace the default 5e NPC sheet with an improved version. No change to the underlying data is made.",
-    "version": "0.9.1",
+    "version": "0.9.2",
     "author": "Felix#6196",
     "systems": ["dnd5e"],
     "esmodules": ["/betternpcsheet.js"],

--- a/module.json
+++ b/module.json
@@ -35,6 +35,9 @@
           "path": "lang/de.json"
         }
     ],
+	"url": "https://github.com/Dinopaterno22/BetterNPCSheet5e",
+    "manifest": "https://github.com/Dinopaterno22/BetterNPCSheet5e/blob/master/module.json",
+    "download": "https://github.com/Dinopaterno22/BetterNPCSheet5e/archive/master.zip",
     "minimumCoreVersion": "0.6.3",
     "compatibleCoreVersion": "0.7.10"
 }

--- a/module.json
+++ b/module.json
@@ -5,7 +5,6 @@
     "version": "0.9.1",
     "author": "Felix#6196",
     "systems": ["dnd5e"],
-    "scripts": [],
     "esmodules": ["/betternpcsheet.js"],
     "styles": ["/css/betternpcsheet.css", "css/rpg-awesome.css"],
     "packs": [],
@@ -36,9 +35,6 @@
           "path": "lang/de.json"
         }
     ],
-    "url": "https://github.com/syl3r86/BetterNPCSheet5e",
-    "manifest": "https://raw.githubusercontent.com/syl3r86/BetterNPCSheet5e/master/module.json",
-    "download": "https://github.com/syl3r86/BetterNPCSheet5e/archive/master.zip",
     "minimumCoreVersion": "0.6.3",
-    "compatibleCoreVersion": "0.7.5"
+    "compatibleCoreVersion": "0.7.10"
 }

--- a/template/npc-sheet.html
+++ b/template/npc-sheet.html
@@ -71,10 +71,17 @@
                         <a class="npc-roll-hp" title="{{ localize "BNPCSheet.RollHP" }}"><i class="fas fa-dice-d20"></i></a>
                         <span class="flex0">)</span>
                     </div>
-                    <div class="flex-line">
-                        <label class="flex">{{ localize "DND5E.Speed" }}</label>
-                        <input class="npc-textinput-small flex" name="data.attributes.speed.value" type="text" value="{{data.attributes.speed.value}}" placeholder="30 ft." />
-                        <input class="npc-textinput-small flex" name="data.attributes.speed.special" type="text" value="{{data.attributes.speed.special}}" placeholder="Special Movement" />
+                    <div class="form-group-stacked hidable">
+                        <a class="config-button" data-action="movement"><b>{{
+                                localize "DND5E.Speed" }}</b></a>
+                        <ul class="traits-list">
+                            {{#if movement.primary}}
+                            <li class="tag">{{movement.primary}}</li>
+                            {{/if}}
+                            {{#if movement.special}}
+                            <li class="tag">{{movement.special}}</li>
+                            {{/if}}
+                        </ul>
                     </div>
                 </div>
                 <div class="sheet-divider"></div><div class="sheet-divider-left"></div>

--- a/template/npc-sheet.html
+++ b/template/npc-sheet.html
@@ -164,7 +164,7 @@
 
                 <!-- Others -->
                 <div class="flex-line hidable" data-hidable-attr="{{data.traits.perception.value}}">
-                    <label><b>{{localize "DND5E.PassivePerception"}} </b></label>
+                    <label><b>{{localize "BNPCSheet.PassivePerception"}} </b></label>
                     <input class="npc-textinput-small hidable-attr" type="text" name="data.skills.prc.passive"
                         data-dtype="{{data.skills.prc.passive}}" value="{{data.skills.prc.passive}}"
                         placeholder="Value" />

--- a/template/npc-sheet.html
+++ b/template/npc-sheet.html
@@ -165,8 +165,9 @@
                 <!-- Others -->
                 <div class="flex-line hidable" data-hidable-attr="{{data.traits.perception.value}}">
                     <label><b>{{localize "DND5E.PassivePerception"}} </b></label>
-                    <input class="npc-textinput-small hidable-attr" type="text" name="data.traits.perception.value" data-dtype="{{data.traits.perception.type}}"
-                           value="{{data.traits.perception.value}}" placeholder="Value" />
+                    <input class="npc-textinput-small hidable-attr" type="text" name="data.skills.prc.passive"
+                        data-dtype="{{data.skills.prc.passive}}" value="{{data.skills.prc.passive}}"
+                        placeholder="Value" />
                 </div>
                 <div class="hidable" data-hidable-attr="{{data.traits.senses}}">
                     <label><b>{{localize "DND5E.Senses"}} </b></label>

--- a/template/npc-sheet.html
+++ b/template/npc-sheet.html
@@ -169,8 +169,10 @@
                         data-dtype="{{data.skills.prc.passive}}" value="{{data.skills.prc.passive}}"
                         placeholder="Value" />
                 </div>
-                <div class="hidable" data-hidable-attr="{{data.traits.senses}}">
-                    <label><b>{{localize "DND5E.Senses"}} </b></label>
+                <div class="form-group-stacked hidable" data-hidable-attr="{{data.traits.senses}}">
+                    <label for="data.traits.senses"></label>
+                    <a class="trait-selector config-button" data-action="senses"><b>{{localize
+                            "DND5E.Senses"}}</b></a>
                     <ul class="traits-list">
                         {{#each senses as |v k|}}
                         <li class="tag {{k}}">{{v}}</li>

--- a/template/npc-sheet.html
+++ b/template/npc-sheet.html
@@ -171,8 +171,11 @@
                 </div>
                 <div class="hidable" data-hidable-attr="{{data.traits.senses}}">
                     <label><b>{{localize "DND5E.Senses"}} </b></label>
-                    <input class="npc-textinput-small" type="text" name="data.traits.senses" data-dtype="String"
-                           value="{{#if data.traits.senses.value}}{{data.traits.senses.value}}{{else}}{{data.traits.senses}}{{/if}}" placeholder="None" />
+                    <ul class="traits-list">
+                        {{#each senses as |v k|}}
+                        <li class="tag {{k}}">{{v}}</li>
+                        {{/each}}
+                    </ul>
                 </div>
                 <div class="form-group-stacked hidable" data-hidable-attr="{{data.traits.languages.value}}{{data.traits.languages.custom}}">
                     <label for="data.traits.languages"></label>


### PR DESCRIPTION
The other PR contained a changed to the readme.md which I did not find worth to add here (I wanted to add a link to the current version of the manifest, so it wouldn't be nice to add it here, hence having redone the PR now). 

Currently it opens and allows the user to edit the "Senses" menu, as with the normal NPC character sheet. 
![image](https://user-images.githubusercontent.com/470602/120114510-bf55a300-c17f-11eb-8e9e-58f97afddaf1.png)

Also visible here is that it now displays the correct text for the passive perception. 