### PR TITLE
Update DEFAULT_TOKEN to be CONST.DEFAULT_TOKEN

### DIFF
--- a/betternpcsheet.js
+++ b/betternpcsheet.js
@@ -268,7 +268,7 @@ export class BetterNPCActor5eSheet extends ActorSheet5eNPC {
 
         // Iterate through items, allocating to containers
         for (let i of actorData.items) {
-            i.img = i.img || DEFAULT_TOKEN;
+            i.img = i.img || CONST.DEFAULT_TOKEN;
 
             i.hasUses = i.data.uses && (i.data.uses.max > 0);
             i.isOnCooldown = i.data.recharge && !!i.data.recharge.value && (i.data.recharge.charged === false);


### PR DESCRIPTION
This was causing the following exception. 

VM16471:1 Uncaught ReferenceError: DEFAULT_TOKEN is not defined
    at eval (eval at _prepareItems (betternpcsheet.js:271), <anonymous>:1:1)
    at BetterNPCActor5eSheet._prepareItems (betternpcsheet.js:271)
    at BetterNPCActor5eSheet.getData (base.js:134)
    at BetterNPCActor5eSheet.getData (npc.js:80)
    at BetterNPCActor5eSheet.getData (betternpcsheet.js:39)
    at BetterNPCActor5eSheet._render (foundry.js:2049)
    at x.🎁call_wrapped [as call_wrapped] (libWrapper-wrapper.js:465)
    at BetterNPCActor5eSheet.🎁Application.prototype._render#lib-wrapper (listeners.js:75)
    at BetterNPCActor5eSheet.🎁Application.prototype._render#0 (libWrapper-wrapper.js:160)
    at BetterNPCActor5eSheet._render (foundry.js:2736)